### PR TITLE
Added useful iOS parameters

### DIFF
--- a/lib/fastlane/plugin/firebase_management/actions/firebase_add_app_action.rb
+++ b/lib/fastlane/plugin/firebase_management/actions/firebase_add_app_action.rb
@@ -23,13 +23,14 @@ module Fastlane
 				type = params[:type].to_sym
 
 				bundle_id = params[:bundle_id]
-
 				display_name = params[:display_name]
+				app_store_id = params[:app_store_id]
+				team_id = params[:team_id]
 
 				case type
 				when :ios
 					# create new ios app on Firebase
-					api.add_ios_app(project_id, bundle_id, display_name)
+					api.add_ios_app(project_id, bundle_id, display_name, app_store_id, team_id)
 
 					# App creation is a long-running operation.
 					# Creation endpoint returns operation ID which should be used to check
@@ -140,6 +141,16 @@ module Fastlane
 											env_name: "FIREBASE_DISPLAY_NAME",
 										 description: "Display name",
 											optional: true),
+
+					FastlaneCore::ConfigItem.new(key: :app_store_id,
+                                  env_name: "FIREBASE_APP_STORE_ID",
+                               description: "AppStore ID",
+                                  optional: true),
+
+					FastlaneCore::ConfigItem.new(key: :team_id,
+                                  env_name: "FIREBASE_TEAM_ID",
+                               description: "Team ID",
+                                  optional: true),
 
 					FastlaneCore::ConfigItem.new(key: :output_path,
 					                        env_name: "FIREBASE_OUTPUT_PATH",

--- a/lib/fastlane/plugin/firebase_management/actions/firebase_add_app_sha_action.rb
+++ b/lib/fastlane/plugin/firebase_management/actions/firebase_add_app_sha_action.rb
@@ -30,7 +30,7 @@ module Fastlane
 					Actions::FirebaseManagementDownloadConfigAction.run(
 						service_account_json_path: params[:service_account_json_path],
 						project_id: project_id,
-						app_id: app["appId"],
+						app_id: app_id,
 						type: type,
 						output_path: params[:output_path]
 					)
@@ -83,7 +83,7 @@ module Fastlane
 
 					FastlaneCore::ConfigItem.new(key: :sha_hash,
 											env_name: "FIREBASE_SHA_HASH",
-										 description: "Sha hash",
+										 description: "SHA hash",
 											optional: false),
 
 					FastlaneCore::ConfigItem.new(key: :download_config,

--- a/lib/fastlane/plugin/firebase_management/actions/firebase_download_config_action.rb
+++ b/lib/fastlane/plugin/firebase_management/actions/firebase_download_config_action.rb
@@ -42,7 +42,7 @@ module Fastlane
 
 				UI.success "Successfuly saved config at #{path}"
 
-				return nil
+				return app_id
 			end
 
 			def self.description

--- a/lib/fastlane/plugin/firebase_management/lib/api.rb
+++ b/lib/fastlane/plugin/firebase_management/lib/api.rb
@@ -85,10 +85,12 @@ module Fastlane
                                 apps
                         end
 
-			def add_ios_app(project_id, bundle_id, app_name)
+			def add_ios_app(project_id, bundle_id, app_name, app_store_id, team_id)
 				parameters = {
 					"bundleId" => bundle_id,
-					"displayName" => app_name || ""
+					"displayName" => app_name || "",
+					"appStoreId" => app_store_id || "",
+					"teamId" => team_id || ""
 				}
 				
 				request_json("v1beta1/projects/#{project_id}/iosApps", :post, parameters)


### PR DESCRIPTION
In order to work with dynamic links, Firebase needs 2 parameters on iOS:
- AppStore ID
- Team ID

This is documented here: https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.iosApps#resource:-iosapp

